### PR TITLE
add role to deploy and configure chrony as ntp client

### DIFF
--- a/inventory/corax
+++ b/inventory/corax
@@ -24,6 +24,9 @@ proxy-00.unterberg.radiocorax.de
 radioco-00.unterberg.radiocorax.de
 stream-00.unterberg.radiocorax.de
 
+[time_server]
+ntp-00.unterberg.radiocorax.de
+
 [monitoring_server]
 monitor-00.unterberg.radiocorax.de
 

--- a/ntp.yml
+++ b/ntp.yml
@@ -1,0 +1,7 @@
+---
+- hosts: all:!legacy
+  gather_facts: False
+  become: True
+  roles:
+    - role: ntp
+      ntp_server: "zeit.unterberg.radiocorax.de"

--- a/ntp.yml
+++ b/ntp.yml
@@ -1,5 +1,5 @@
 ---
-- hosts: all:!legacy
+- hosts: all:!time_server:!legacy
   gather_facts: False
   become: True
   roles:

--- a/roles/ntp/handlers/main.yml
+++ b/roles/ntp/handlers/main.yml
@@ -1,0 +1,5 @@
+---
+- name: restart chrony
+  service:
+    name: chrony
+    state: restarted

--- a/roles/ntp/tasks/main.yml
+++ b/roles/ntp/tasks/main.yml
@@ -1,0 +1,12 @@
+---
+- name: install chrony
+  apt:
+    name: chrony
+    update_cache: yes
+    state: present
+- name: copy chrony.conf
+  template:
+    src: templates/chrony.conf.j2
+    dest: /etc/chrony/chrony.conf
+    mode: 0o644
+  notify: restart chrony

--- a/roles/ntp/templates/chrony.conf.j2
+++ b/roles/ntp/templates/chrony.conf.j2
@@ -1,0 +1,47 @@
+# Welcome to the chrony configuration file. See chrony.conf(5) for more
+# information about usable directives.
+
+# Include configuration files found in /etc/chrony/conf.d.
+confdir /etc/chrony/conf.d
+
+# Use corax ntp-server
+pool {{ ntp_server }} iburst
+
+# Use time sources from DHCP.
+sourcedir /run/chrony-dhcp
+
+# Use NTP sources found in /etc/chrony/sources.d.
+sourcedir /etc/chrony/sources.d
+
+# This directive specify the location of the file containing ID/key pairs for
+# NTP authentication.
+keyfile /etc/chrony/chrony.keys
+
+# This directive specify the file into which chronyd will store the rate
+# information.
+driftfile /var/lib/chrony/chrony.drift
+
+# Save NTS keys and cookies.
+ntsdumpdir /var/lib/chrony
+
+# Uncomment the following line to turn logging on.
+#log tracking measurements statistics
+
+# Log files location.
+logdir /var/log/chrony
+
+# Stop bad estimates upsetting machine clock.
+maxupdateskew 100.0
+
+# This directive enables kernel synchronisation (every 11 minutes) of the
+# real-time clock. Note that it can't be used along with the 'rtcfile' directive.
+rtcsync
+
+# Step the system clock instead of slewing it if the adjustment is larger than
+# one second, but only in the first three clock updates.
+makestep 1 3
+
+# Get TAI-UTC offset and leap seconds from the system tz database.
+# This directive must be commented out when using time sources serving
+# leap-smeared time.
+leapsectz right/UTC

--- a/site.yml
+++ b/site.yml
@@ -5,3 +5,4 @@
 - import_playbook: utils.yml
 - import_playbook: smart.yml
 - import_playbook: unattended_upgrades.yml
+- import_playbook: ntp.yml


### PR DESCRIPTION
- getestet an lokaler VM
- eventuell konfiguriertes _ntpsec_ oder _systemd-timesyncd_  werden automatisch deinstalliert