### PR TITLE
fix wrong hostname in zabbix-agent conf + add monitoring to site

### DIFF
--- a/roles/zabbix/templates/zabbix_agent2.conf.j2
+++ b/roles/zabbix/templates/zabbix_agent2.conf.j2
@@ -139,7 +139,6 @@ ServerActive=127.0.0.1
 # Default:
 # Hostname=
 
-Hostname=Zabbix server
 
 ### Option: HostnameItem
 #	Item used for generating Hostname if it is undefined. Ignored if Hostname is defined.
@@ -147,7 +146,7 @@ Hostname=Zabbix server
 #
 # Mandatory: no
 # Default:
-# HostnameItem=system.hostname
+HostnameItem=system.hostname
 
 ### Option: HostMetadata
 #	Optional parameter that defines host metadata.

--- a/site.yml
+++ b/site.yml
@@ -5,3 +5,4 @@
 - import_playbook: utils.yml
 - import_playbook: smart.yml
 - import_playbook: unattended_upgrades.yml
+- import_playbook: monitoring.yml


### PR DESCRIPTION
- in der zabbix-agent conf war der hostname für alle auf "zabbix-server" gesetzt
- ich habe monitoring zu site.yml hinzugefügt